### PR TITLE
修正字幕抓不到及README

### DIFF
--- a/BahaAssert/main.lua
+++ b/BahaAssert/main.lua
@@ -12,22 +12,16 @@ function log(string,secs)
 end
 -- extract string between colons
 function extract_between_colons(input_string)
-    local start_index = 0
-    local end_index = 0
-    local count = 0
-    for i = 1, #input_string do
-        if input_string:sub(i, i) == ":" then
-            count = count + 1
-            if count == 2 then
-                start_index = i
-            elseif count == 3 then
-                end_index = i
-                break
-            end
-        end
-    end
-    if start_index > 0 and end_index > 0 then
-        return input_string:sub(start_index + 1, end_index - 1)
+    local start_index = input_string:find("%%3A")
+    if not start_index then return nil end
+    start_index = start_index + 3 -- move past %3A
+
+    local end_index = input_string:find("%%3A", start_index)
+    if not end_index then return nil end
+
+    local result = input_string:sub(start_index, end_index - 1)
+    if result:match("^%d+$") and #result <= 10 then
+        return result
     else
         return nil
     end

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # MPV-Play-BAHA-Comments
-配合 Play-with-MPV 自動產生動畫瘋原生風格的彈幕
+配合 External Player 自動產生動畫瘋原生風格的彈幕
 # 運行效果
 ![螢幕擷取畫面 2024-02-19 211436](https://github.com/s594569321/MPV-Play-BAHA-Comments/assets/81683926/e053f6b1-71de-4a30-9b47-029402d74521)
 # 安裝

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 # 運行效果
 ![螢幕擷取畫面 2024-02-19 211436](https://github.com/s594569321/MPV-Play-BAHA-Comments/assets/81683926/e053f6b1-71de-4a30-9b47-029402d74521)
 # 安裝
-1.安裝 Play-With-MPV Tampermonkey腳本  
+1.安裝 External Player  
 
-腳本載點: https://greasyfork.org/zh-CN/scripts/444056-play-with-mpv  
+專案連結: https://github.com/LuckyPuppy514/external-player  
 
 2.將 BahaAssert 放在 MPV 資料夾底下的 scripts 資料夾內
 # 快捷功能


### PR DESCRIPTION
由於Play-With-MPV腳本逐漸失效，原作者重寫了一個新專案叫做External Player，使用此專案的時候這個script會抓不到字幕，故有此改動，並且在README貼上External Player的連結。